### PR TITLE
Add a JSON summary publisher; fix Bug #3

### DIFF
--- a/PHPADD/Cli.php
+++ b/PHPADD/Cli.php
@@ -90,6 +90,7 @@ class PHPADD_Cli
 			"   --publish-html <file>     HTML output" . PHP_EOL .
 			"   --publish-xml  <file>     XML output" . PHP_EOL .
 			"   --publish-delim <file>    Tab delimited output" . PHP_EOL;
+			"   --publish-overview <file> JSON statistical output" . PHP_EOL;
 
 
 	}
@@ -130,6 +131,11 @@ class PHPADD_Cli
 				case '--publish-delim':
 					require_once "Publisher/Delim.php";
 					$this->addPublisher('Delim', $_SERVER['argv'][++$i]);
+					break;
+					
+				case '--publish-json-overview':
+					require_once "Publisher/Overview.php";
+					$this->addPublisher('Overview', $_SERVER['argv'][++$i]);
 					break;
 
 

--- a/PHPADD/Parser.php
+++ b/PHPADD/Parser.php
@@ -121,7 +121,23 @@ class PHPADD_Parser
 		if (isset($annotations['param'])) {
 			foreach ($annotations['param'] as $parameter)
 			{
-				list($type, $name) = preg_split("/[\s]+/", $parameter);
+			    
+				$parameterParts = preg_split("/[\s]+/", $parameter);
+				
+				if (count($parameterParts) < 2) {
+				    // Some automatically generated docblocks may be invalid,
+				    // and only provide a datatype OR a variable name. Determine
+				    // which it is, and output appropriately
+				    if (substr($parameterParts[0], 0, 1) === '$') {
+				        $name = $parameterParts[0];
+				        $type = '';
+				    } else {
+				        $name = '';
+				        $type = $parameterParts[0];
+				    }
+				} else {
+				    list($type, $name) = $parameterParts;
+				}
 
 				if (!in_array($type, $excluded)) {
 					$params[] = "$type $name";

--- a/PHPADD/Publisher/Overview.php
+++ b/PHPADD/Publisher/Overview.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * phpadd - abandoned docblocks detector
+ * Copyright (C) 2010 Francesco Montefoschi <francesco.monte@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package phpadd
+ * @author  Francesco Montefoschi
+ * @license http://www.gnu.org/licenses/gpl-3.0.html  GNU GPL 3.0
+ */
+
+class PHPADD_Publisher_Overview extends PHPADD_Publisher_Abstract
+{
+	/**
+	 * Renders the mess in an HTML page.
+	 *
+	 * @param PHPADD_Result_Analysis $mess
+	 */
+	public function publish(PHPADD_Result_Analysis $mess)
+	{
+	    $helper = new PHPADD_Stats();
+		$stats = $helper->getStats($mess);
+		
+		$output = json_encode($stats);
+	    
+		file_put_contents($this->destination, $output);
+	}
+}


### PR DESCRIPTION
See bug #3.

The JSON summary publisher is to allow easy recording of the data for trending purposes.
